### PR TITLE
Add pandoc microservice

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,8 @@ FROM golang:1.21-alpine
 WORKDIR /app
 
 RUN apk update && \
-    apk add openssl && \
-  openssl s_client -connect helloworld.letsencrypt.org:443 -showcerts </dev/null 2>/dev/null | sed -e '/-----BEGIN/,/-----END/!d' | tee "/usr/local/share/ca-certificates/ca.crt" >/dev/null && \
-  update-ca-certificates
+    apk add bash ca-certificates && \
+    update-ca-certificates
 
 COPY . ./
 RUN go mod download && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.21-alpine
 WORKDIR /app
 
 RUN apk update && \
-    apk add bash ca-certificates && \
+    apk add curl bash ca-certificates && \
     update-ca-certificates
 
 COPY . ./

--- a/docker-images/pandoc/Dockerfile
+++ b/docker-images/pandoc/Dockerfile
@@ -1,7 +1,7 @@
 ARG TAG=main
 ARG DOCKER_REPOSITORY=local
 FROM ${DOCKER_REPOSITORY}/scyllaridae:${TAG} AS scyllaridae
-FROM pandoc/core:3.1.1 AS pandoc
+FROM pandoc/latex:3.1.1 AS pandoc
 
 WORKDIR /app
 COPY --from=scyllaridae /app/scyllaridae /app/scyllaridae

--- a/docker-images/pandoc/Dockerfile
+++ b/docker-images/pandoc/Dockerfile
@@ -1,0 +1,8 @@
+ARG TAG=main
+ARG DOCKER_REPOSITORY=local
+FROM ${DOCKER_REPOSITORY}/scyllaridae:${TAG} AS scyllaridae
+
+FROM pandoc/minimal:3.1.1
+WORKDIR /app
+COPY --from=scyllaridae /app/scyllaridae .
+COPY scyllaridae.yml .

--- a/docker-images/pandoc/Dockerfile
+++ b/docker-images/pandoc/Dockerfile
@@ -4,6 +4,9 @@ FROM ${DOCKER_REPOSITORY}/scyllaridae:${TAG} AS scyllaridae
 
 FROM pandoc/minimal:3.1.1
 WORKDIR /app
+RUN apk update && \
+    apk add curl bash ca-certificates && \
+    update-ca-certificates
 COPY --from=scyllaridae /app/scyllaridae .
 COPY scyllaridae.yml .
 ENTRYPOINT ["/app/scyllaridae"]

--- a/docker-images/pandoc/Dockerfile
+++ b/docker-images/pandoc/Dockerfile
@@ -1,12 +1,8 @@
 ARG TAG=main
 ARG DOCKER_REPOSITORY=local
-FROM ${DOCKER_REPOSITORY}/scyllaridae:${TAG} AS scyllaridae
+FROM pandoc/minimal:3.1.1 AS pandoc
+FROM ${DOCKER_REPOSITORY}/scyllaridae:${TAG}
 
-FROM pandoc/minimal:3.1.1
-WORKDIR /app
-RUN apk update && \
-    apk add curl bash ca-certificates && \
-    update-ca-certificates
-COPY --from=scyllaridae /app/scyllaridae .
+COPY --from=pandoc /usr/local/bin/pandoc /usr/local/bin/pandoc
 COPY scyllaridae.yml .
 ENTRYPOINT ["/app/scyllaridae"]

--- a/docker-images/pandoc/Dockerfile
+++ b/docker-images/pandoc/Dockerfile
@@ -3,7 +3,7 @@ ARG DOCKER_REPOSITORY=local
 FROM ${DOCKER_REPOSITORY}/scyllaridae:${TAG} AS scyllaridae
 FROM pandoc/core:3.1.1 AS pandoc
 
-WORKDIR /app/scyllaridae
+WORKDIR /app
 COPY --from=scyllaridae /app/scyllaridae /app/scyllaridae
 COPY scyllaridae.yml .
 ENTRYPOINT ["/app/scyllaridae"]

--- a/docker-images/pandoc/Dockerfile
+++ b/docker-images/pandoc/Dockerfile
@@ -6,3 +6,4 @@ FROM pandoc/minimal:3.1.1
 WORKDIR /app
 COPY --from=scyllaridae /app/scyllaridae .
 COPY scyllaridae.yml .
+ENTRYPOINT ["/app/scyllaridae"]

--- a/docker-images/pandoc/Dockerfile
+++ b/docker-images/pandoc/Dockerfile
@@ -1,6 +1,6 @@
 ARG TAG=main
 ARG DOCKER_REPOSITORY=local
-FROM pandoc/minimal:3.1.1 AS pandoc
+FROM pandoc/core:3.1.1 AS pandoc
 FROM ${DOCKER_REPOSITORY}/scyllaridae:${TAG}
 
 COPY --from=pandoc /usr/local/bin/pandoc /usr/local/bin/pandoc

--- a/docker-images/pandoc/Dockerfile
+++ b/docker-images/pandoc/Dockerfile
@@ -1,8 +1,9 @@
 ARG TAG=main
 ARG DOCKER_REPOSITORY=local
+FROM ${DOCKER_REPOSITORY}/scyllaridae:${TAG} AS scyllaridae
 FROM pandoc/core:3.1.1 AS pandoc
-FROM ${DOCKER_REPOSITORY}/scyllaridae:${TAG}
 
-COPY --from=pandoc /usr/local/bin/pandoc /usr/local/bin/pandoc
+WORKDIR /app/scyllaridae
+COPY --from=scyllaridae /app/scyllaridae /app/scyllaridae
 COPY scyllaridae.yml .
 ENTRYPOINT ["/app/scyllaridae"]

--- a/docker-images/pandoc/scyllaridae.yml
+++ b/docker-images/pandoc/scyllaridae.yml
@@ -1,8 +1,9 @@
 destinationHttpMethod: PUT
 allowedMimeTypes:
   - "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+  - "application/xml"
 cmdByMimeType:
-  application/vnd.openxmlformats-officedocument.wordprocessingml.document:
+  default:
     cmd: /usr/local/bin/pandoc
     args:
       - "-f"

--- a/docker-images/pandoc/scyllaridae.yml
+++ b/docker-images/pandoc/scyllaridae.yml
@@ -1,13 +1,11 @@
 destinationHttpMethod: PUT
-allowedMimeTypes: [
-  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-]
+allowedMimeTypes:
+  - "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
 cmdByMimeType:
-  "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+  application/vnd.openxmlformats-officedocument.wordprocessingml.document:
     cmd: /usr/local/bin/pandoc
-    args: [
-      "-f"
-      "docx"
-      "-t"
-      "pdf"
-    ]
+    args:
+      - "-f"
+      - "docx"
+      - "-t"
+      - "pdf"

--- a/docker-images/pandoc/scyllaridae.yml
+++ b/docker-images/pandoc/scyllaridae.yml
@@ -1,0 +1,13 @@
+destinationHttpMethod: PUT
+allowedMimeTypes: [
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+]
+cmdByMimeType:
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+    cmd: /usr/local/bin/pandoc
+    args: [
+      "-f"
+      "docx"
+      "-t"
+      "pdf"
+    ]


### PR DESCRIPTION
Adding new microservice:

1. This PR
2. Update docker-compose.yml to deploy this service's docker image
```
    pandoc-dev: &pandoc
        <<: [*dev, *common]
        image: ${DOCKER_REPOSITORY}/scyllaridae-pandoc:pandoc
        networks:
            default:
                aliases:
                    - pandoc
    pandoc-prod: &pandoc-prod
        <<: [*prod, *pandoc]
```
3. Update alpaca.properties
```
derivative.pandoc.enabled=true
derivative.pandoc.in.stream=queue:islandora-connector-pandoc
derivative.pandoc.service.url=http://pandoc:8080/
derivative.pandoc.concurrent-consumers=-1
derivative.pandoc.max-concurrent-consumers=-1
derivative.pandoc.async-consumer=true
```
4. Add an action in Islandora
5. Add a context to trigger the action