### PR TITLE
[minor] Provide a mimetype to extension utility

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -18,11 +18,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      -
-        name: Set up Go
-        uses: actions/setup-go@v3
-      -
-        name: Run GoReleaser
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.22.2'
+
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser

--- a/.github/workflows/lint-test-build.yml
+++ b/.github/workflows/lint-test-build.yml
@@ -12,7 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.22.2'
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 scyllaridae
+scyllaridae.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine
+FROM golang:1.22-alpine
 
 WORKDIR /app
 

--- a/docker-images/ffmpeg/scyllaridae.yml
+++ b/docker-images/ffmpeg/scyllaridae.yml
@@ -4,52 +4,12 @@ allowedMimeTypes:
   - "image/jpeg"
   - "image/png"
 cmdByMimeType:
-  "video/x-msvideo":
-    cmd: ffmpeg
-    args:
-      - "-i"
-      - "-"
-      - "%s"
-      - "-f"
-      - "avi"
-  "video/ogg":
-    cmd: ffmpeg
-    args:
-      - "-i"
-      - "-"
-      - "%s"
-      - "-f"
-      - "ogg"
-  "audio/x-wav":
-    cmd: ffmpeg
-    args:
-      - "-i"
-      - "-"
-      - "%s"
-      - "-f"
-      - "wav"
-  "audio/mpeg":
-    cmd: ffmpeg
-    args:
-      - "-i"
-      - "-"
-      - "%s"
-      - "-f"
-      - "mp3"
-  "audio/aac":
-    cmd: ffmpeg
-    args:
-      - "-i"
-      - "-"
-      - "%s"
-      - "-f"
-      - "m4a"
   "image/jpeg":
     cmd: ffmpeg
     args:
       - "-i"
       - "-"
-      - "%s"
+      - "%args"
       - "-f"
       - "image2pipe"
   "image/png":
@@ -57,7 +17,7 @@ cmdByMimeType:
     args:
       - "-i"
       - "-"
-      - "%s"
+      - "%args"
       - "-f"
       - "image2pipe"
   "video/mp4":
@@ -65,7 +25,7 @@ cmdByMimeType:
     args:
       - "-i"
       - "-"
-      - "%s"
+      - "%args"
       - "-vcodec"
       - "libx264"
       - "-preset"
@@ -85,4 +45,15 @@ cmdByMimeType:
       - "-y"
       - "-f"
       - "mp4"
+      - "-"
+  default:
+    cmd: ffmpeg
+    args:
+      - "-f"
+      - "%source-mime-ext"
+      - "-i"
+      - "-"
+      - "%args"
+      - "-f"
+      - "%destination-mime-ext"
       - "-"

--- a/docker-images/imagemagick/scyllaridae.yml
+++ b/docker-images/imagemagick/scyllaridae.yml
@@ -6,11 +6,11 @@ cmdByMimeType:
     cmd: convert
     args:
       - "pdf:-[0]"
-      - "%s"
+      - "%args"
       - "pdf:-"
   default:
     cmd: convert
     args:
       - "-"
-      - "%s"
+      - "%args"
       - "image:-"

--- a/docker-images/pandoc/scyllaridae.yml
+++ b/docker-images/pandoc/scyllaridae.yml
@@ -1,11 +1,10 @@
 allowedMimeTypes:
-  - "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-  - "application/xml"
+  - "text/csv"
 cmdByMimeType:
   default:
     cmd: /usr/local/bin/pandoc
     args:
       - "-f"
-      - "docx"
+      - "%source-mime-ext"
       - "-t"
       - "pdf"

--- a/docker-images/pandoc/scyllaridae.yml
+++ b/docker-images/pandoc/scyllaridae.yml
@@ -7,4 +7,4 @@ cmdByMimeType:
       - "-f"
       - "%source-mime-ext"
       - "-t"
-      - "pdf"
+      - "%destination-mime-ext"

--- a/docker-images/tesseract/scyllaridae.yml
+++ b/docker-images/tesseract/scyllaridae.yml
@@ -5,7 +5,7 @@ cmdByMimeType:
   "application/pdf":
     cmd: pdftotext
     args:
-      - "%s"
+      - "%args"
       - "-"
       - "-"
   default:
@@ -13,4 +13,4 @@ cmdByMimeType:
     args:
       - "stdin"
       - "stdout"
-      - "%s"
+      - "%args"

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,16 @@
 module github.com/lehigh-university-libraries/scyllaridae
 
-go 1.21.3
+go 1.22.2
 
-require gopkg.in/yaml.v3 v3.0.1
+require (
+	github.com/stretchr/testify v1.9.0
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
-	github.com/stretchr/testify v1.9.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"log/slog"
 	"mime"
 	"os"
 	"os/exec"
@@ -132,20 +131,18 @@ func BuildExecCommand(sourceMimeType, destinationMimeType, addtlArgs string, c *
 		} else if a == "%source-mime-ext" {
 			extensions, err := mime.ExtensionsByType(sourceMimeType)
 			if err != nil || len(extensions) == 0 {
-				slog.Error("unknown mime extension", "mimetype", sourceMimeType, "err", err)
 				return nil, fmt.Errorf("unknown mime extension: %s", sourceMimeType)
 			}
-			args = append(args, strings.TrimPrefix(extensions[0], "."))
+			args = append(args, strings.TrimPrefix(extensions[len(extensions)-1], "."))
 
 			// if we have the special value of %destination-mime-ext
 			// replace it with the source mimetype extension
 		} else if a == "%destination-mime-ext" {
 			extensions, err := mime.ExtensionsByType(destinationMimeType)
 			if err != nil || len(extensions) == 0 {
-				slog.Error("unknown mime extension", "mimetype", destinationMimeType, "err", err)
 				return nil, fmt.Errorf("unknown mime extension: %s", destinationMimeType)
 			}
-			args = append(args, strings.TrimPrefix(extensions[0], "."))
+			args = append(args, strings.TrimPrefix(extensions[len(extensions)-1], "."))
 
 		} else {
 			args = append(args, a)

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -156,6 +156,9 @@ func BuildExecCommand(sourceMimeType, destinationMimeType, addtlArgs string, c *
 }
 
 func getMimeTypeExtension(mimeType string) (string, error) {
+	// since the std mimetype -> extension conversion returns a list
+	// we need to override the default extension to use
+	// it also is missing some mimetypes
 	mimeToExtension := map[string]string{
 		"application/msword":            "doc",
 		"application/vnd.ms-excel":      "xls",
@@ -163,9 +166,18 @@ func getMimeTypeExtension(mimeType string) (string, error) {
 
 		"image/svg+xml": "svg",
 		"image/webp":    "webp",
+		"image/jp2":     "jp2",
+		"image/bmp":     "bmp",
 
-		"video/mp4":       "mp4",
-		"video/quicktime": "mov",
+		"video/mp4":                     "mp4",
+		"video/quicktime":               "mov",
+		"video/x-ms-asf":                "asx",
+		"video/mp2t":                    "ts",
+		"video/mpeg":                    "mpg",
+		"application/vnd.apple.mpegurl": "m3u8",
+		"video/3gpp":                    "3gp",
+		"video/x-m4v":                   "m4v",
+		"video/x-msvideo":               "avi",
 
 		"audio/ogg":         "ogg",
 		"audio/webm":        "webm",

--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ func MessageHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// build a command to run that we will pipe the stdin stream into
-	cmd, err := scyllaridae.BuildExecCommand(message.Attachment.Content.SourceMimeType, message.Attachment.Content.Args, config)
+	cmd, err := scyllaridae.BuildExecCommand(message.Attachment.Content.SourceMimeType, message.Attachment.Content.DestinationMimeType, message.Attachment.Content.Args, config)
 	if err != nil {
 		slog.Error("Error building command", "err", err)
 		http.Error(w, "Internal error", http.StatusInternalServerError)

--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ func MessageHandler(w http.ResponseWriter, r *http.Request) {
 	req, err := http.NewRequest("GET", message.Attachment.Content.SourceURI, nil)
 	if err != nil {
 		slog.Error("Error creating request to source", "source", message.Attachment.Content.SourceURI, "err", err)
-		http.Error(w, "Internal error", http.StatusInternalServerError)
+		http.Error(w, "Bad request", http.StatusBadRequest)
 		return
 	}
 	if config.ForwardAuth {
@@ -83,7 +83,7 @@ func MessageHandler(w http.ResponseWriter, r *http.Request) {
 	cmd, err := scyllaridae.BuildExecCommand(message.Attachment.Content.SourceMimeType, message.Attachment.Content.DestinationMimeType, message.Attachment.Content.Args, config)
 	if err != nil {
 		slog.Error("Error building command", "err", err)
-		http.Error(w, "Internal error", http.StatusInternalServerError)
+		http.Error(w, "Bad request", http.StatusBadRequest)
 		return
 	}
 	cmd.Stdin = sourceResp.Body

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -257,6 +258,128 @@ cmdByMimeType:
 					t.Fatalf("Unable to read source uri resp body: %v", err)
 				}
 				assert.Equal(t, tt.expectedBody, string(body))
+			}
+		})
+	}
+}
+
+func TestMimeTypes(t *testing.T) {
+	mimeTypes := map[string]string{
+		"application/msword": "doc",
+		"application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",
+		"application/vnd.ms-excel": "xls",
+		"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":         "xlsx",
+		"application/vnd.ms-powerpoint":                                             "ppt",
+		"application/vnd.openxmlformats-officedocument.presentationml.presentation": "pptx",
+
+		"image/jpeg":    "jpg",
+		"image/jp2":     "jp2",
+		"image/png":     "png",
+		"image/gif":     "gif",
+		"image/bmp":     "bmp",
+		"image/svg+xml": "svg",
+		"image/tiff":    "tiff",
+		"image/webp":    "webp",
+
+		"audio/mpeg":        "mp3",
+		"audio/x-wav":       "wav",
+		"audio/ogg":         "ogg",
+		"audio/aac":         "aac",
+		"audio/webm":        "webm",
+		"audio/flac":        "flac",
+		"audio/midi":        "mid",
+		"audio/x-m4a":       "m4a",
+		"audio/x-realaudio": "ra",
+
+		"video/mp4":                     "mp4",
+		"video/x-msvideo":               "avi",
+		"video/x-ms-wmv":                "wmv",
+		"video/mpeg":                    "mpg",
+		"video/webm":                    "webm",
+		"video/quicktime":               "mov",
+		"application/vnd.apple.mpegurl": "m3u8",
+		"video/3gpp":                    "3gp",
+		"video/mp2t":                    "ts",
+		"video/x-flv":                   "flv",
+		"video/x-m4v":                   "m4v",
+		"video/x-mng":                   "mng",
+		"video/x-ms-asf":                "asx",
+
+		"text/plain":      "txt",
+		"text/html":       "html",
+		"application/pdf": "pdf",
+		"text/csv":        "csv",
+	}
+	test := Test{
+		authHeader:          "pass",
+		requestAuth:         "pass",
+		expectedStatus:      http.StatusOK,
+		expectedBody:        "%s txt\n",
+		returnedBody:        "",
+		expectMismatch:      false,
+		destinationMimeType: "text/plain",
+		yml: `
+forwardAuth: false
+allowedMimeTypes:
+  - "*"
+cmdByMimeType:
+  default:
+    cmd: echo
+    args:
+      - "%source-mime-ext"
+      - "%destination-mime-ext"
+`,
+	}
+	for mimeType, extension := range mimeTypes {
+		test.name = fmt.Sprintf("test %s to %s conversion", mimeType, extension)
+		test.mimetype = mimeType
+		test.expectedBody = fmt.Sprintf("%s txt\n", extension)
+		t.Run(test.name, func(t *testing.T) {
+			var err error
+			destinationServer := createMockDestinationServer(t, test.returnedBody)
+			defer destinationServer.Close()
+
+			sourceServer := createMockSourceServer(t, test.mimetype, test.authHeader, destinationServer.URL)
+			defer sourceServer.Close()
+
+			os.Setenv("SCYLLARIDAE_YML", test.yml)
+			// set the config based on test.yml
+			config, err = scyllaridae.ReadConfig("")
+			if err != nil {
+				t.Fatalf("Could not read YML: %v", err)
+				os.Exit(1)
+			}
+
+			// Configure and start the main server
+			setupServer := httptest.NewServer(http.HandlerFunc(MessageHandler))
+			defer setupServer.Close()
+
+			// Send the mock message to the main server
+			req, err := http.NewRequest("GET", setupServer.URL, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set("X-Islandora-Args", destinationServer.URL)
+			// set the mimetype to send to the destination server in the Accept header
+			req.Header.Set("Accept", test.destinationMimeType)
+			req.Header.Set("Authorization", test.requestAuth)
+			req.Header.Set("Apix-Ldp-Resource", sourceServer.URL)
+
+			// Capture the response
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+			assert.Equal(t, test.expectedStatus, resp.StatusCode)
+			if !test.expectMismatch {
+				// if we're setesting up the destination server as the cURL target
+				// make sure it returned
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					t.Fatalf("Unable to read source uri resp body: %v", err)
+				}
+				assert.Equal(t, test.expectedBody, string(body))
 			}
 		})
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -58,7 +58,7 @@ cmdByMimeType:
   default:
     cmd: curl
     args:
-      - "%s"
+      - "%args"
 `,
 		},
 		{
@@ -78,7 +78,7 @@ cmdByMimeType:
   default:
     cmd: curl
     args:
-      - "%s"
+      - "%args"
 `,
 		},
 		{
@@ -98,7 +98,7 @@ cmdByMimeType:
   default:
     cmd: curl
     args:
-      - "%s"
+      - "%args"
 `,
 		},
 		{
@@ -117,7 +117,7 @@ cmdByMimeType:
   default:
     cmd: curl
     args:
-      - "%s"
+      - "%args"
 `,
 		},
 		{
@@ -137,7 +137,7 @@ cmdByMimeType:
   default:
     cmd: curl
     args:
-      - "%s"
+      - "%args"
 `,
 		},
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -11,15 +12,16 @@ import (
 )
 
 type Test struct {
-	name           string
-	authHeader     string
-	requestAuth    string
-	expectedStatus int
-	expectedBody   string
-	returnedBody   string
-	expectMismatch bool
-	yml            string
-	mimetype       string
+	name                string
+	authHeader          string
+	requestAuth         string
+	expectedStatus      int
+	expectedBody        string
+	returnedBody        string
+	expectMismatch      bool
+	yml                 string
+	mimetype            string
+	destinationMimeType string
 }
 
 func TestMessageHandler_MethodNotAllowed(t *testing.T) {
@@ -42,14 +44,15 @@ func TestMessageHandler_MethodNotAllowed(t *testing.T) {
 func TestIntegration(t *testing.T) {
 	tests := []Test{
 		{
-			name:           "cURL pass no auth",
-			authHeader:     "foo",
-			requestAuth:    "bar",
-			expectedStatus: http.StatusOK,
-			returnedBody:   "foo",
-			expectedBody:   "foo",
-			expectMismatch: false,
-			mimetype:       "text/plain",
+			name:                "cURL pass no auth",
+			authHeader:          "foo",
+			requestAuth:         "bar",
+			expectedStatus:      http.StatusOK,
+			returnedBody:        "foo",
+			expectedBody:        "foo",
+			expectMismatch:      false,
+			mimetype:            "text/plain",
+			destinationMimeType: "application/xml",
 			yml: `
 forwardAuth: false
 allowedMimeTypes:
@@ -62,14 +65,15 @@ cmdByMimeType:
 `,
 		},
 		{
-			name:           "cURL fail with bad auth",
-			authHeader:     "foo",
-			requestAuth:    "bar",
-			expectedStatus: http.StatusBadRequest,
-			returnedBody:   "foo",
-			expectedBody:   "foo",
-			expectMismatch: false,
-			mimetype:       "text/plain",
+			name:                "cURL fail with bad auth",
+			authHeader:          "foo",
+			requestAuth:         "bar",
+			expectedStatus:      http.StatusBadRequest,
+			returnedBody:        "foo",
+			expectedBody:        "Bad request\n",
+			expectMismatch:      false,
+			mimetype:            "text/plain",
+			destinationMimeType: "application/xml",
 			yml: `
 forwardAuth: true
 allowedMimeTypes:
@@ -82,14 +86,15 @@ cmdByMimeType:
 `,
 		},
 		{
-			name:           "cURL pass with auth",
-			authHeader:     "pass",
-			requestAuth:    "pass",
-			expectedStatus: http.StatusOK,
-			returnedBody:   "foo",
-			expectedBody:   "foo",
-			expectMismatch: false,
-			mimetype:       "text/plain",
+			name:                "cURL pass with auth",
+			authHeader:          "pass",
+			requestAuth:         "pass",
+			expectedStatus:      http.StatusOK,
+			returnedBody:        "foo",
+			expectedBody:        "foo",
+			expectMismatch:      false,
+			mimetype:            "text/plain",
+			destinationMimeType: "application/xml",
 			yml: `
 forwardAuth: true
 allowedMimeTypes:
@@ -102,13 +107,14 @@ cmdByMimeType:
 `,
 		},
 		{
-			name:           "cURL fail no auth bad output",
-			requestAuth:    "pass",
-			expectedStatus: http.StatusOK,
-			returnedBody:   "foo",
-			expectedBody:   "bar",
-			expectMismatch: true,
-			mimetype:       "text/plain",
+			name:                "cURL fail no auth bad output",
+			requestAuth:         "pass",
+			expectedStatus:      http.StatusOK,
+			returnedBody:        "foo",
+			expectedBody:        "bar",
+			expectMismatch:      true,
+			mimetype:            "text/plain",
+			destinationMimeType: "application/xml",
 			yml: `
 forwardAuth: false
 allowedMimeTypes:
@@ -121,14 +127,15 @@ cmdByMimeType:
 `,
 		},
 		{
-			name:           "cURL fail bad output",
-			authHeader:     "pass",
-			requestAuth:    "pass",
-			expectedStatus: http.StatusOK,
-			returnedBody:   "foo",
-			expectedBody:   "bar",
-			expectMismatch: true,
-			mimetype:       "text/plain",
+			name:                "cURL fail bad output",
+			authHeader:          "pass",
+			requestAuth:         "pass",
+			expectedStatus:      http.StatusOK,
+			returnedBody:        "foo",
+			expectedBody:        "bar",
+			expectMismatch:      true,
+			mimetype:            "text/plain",
+			destinationMimeType: "application/xml",
 			yml: `
 forwardAuth: true
 allowedMimeTypes:
@@ -138,13 +145,75 @@ cmdByMimeType:
     cmd: curl
     args:
       - "%args"
+`,
+		},
+		{
+			name:                "test mimetype to ext conversion",
+			authHeader:          "pass",
+			requestAuth:         "pass",
+			expectedStatus:      http.StatusOK,
+			expectedBody:        "ppt txt\n",
+			expectMismatch:      false,
+			mimetype:            "application/vnd.ms-powerpoint",
+			destinationMimeType: "text/plain",
+			yml: `
+forwardAuth: false
+allowedMimeTypes:
+  - "application/vnd.ms-powerpoint"
+cmdByMimeType:
+  default:
+    cmd: echo
+    args:
+      - "%source-mime-ext"
+      - "%destination-mime-ext"
+`,
+		},
+		{
+			name:                "test bad mimetype succeeds if not getting extension",
+			authHeader:          "pass",
+			requestAuth:         "pass",
+			expectedStatus:      http.StatusOK,
+			expectedBody:        "OK\n",
+			expectMismatch:      false,
+			mimetype:            "application/this-mime-type-doesn't-exist",
+			destinationMimeType: "text/plain",
+			yml: `
+forwardAuth: false
+allowedMimeTypes:
+  - "*"
+cmdByMimeType:
+  default:
+    cmd: echo
+    args:
+      - "OK"
+`,
+		},
+		{
+			name:                "test bad mimetype",
+			authHeader:          "pass",
+			requestAuth:         "pass",
+			expectedStatus:      http.StatusBadRequest,
+			expectedBody:        "Bad request\n",
+			expectMismatch:      false,
+			mimetype:            "application/this-mime-type-doesn't-exist",
+			destinationMimeType: "text/plain",
+			yml: `
+forwardAuth: false
+allowedMimeTypes:
+  - "*"
+cmdByMimeType:
+  default:
+    cmd: echo
+    args:
+      - "%source-mime-ext"
+      - "%destination-mime-ext"
 `,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var err error
-			destinationServer := createMockDestinationServer(tt.returnedBody)
+			destinationServer := createMockDestinationServer(t, tt.returnedBody)
 			defer destinationServer.Close()
 
 			sourceServer := createMockSourceServer(t, tt.mimetype, tt.authHeader, destinationServer.URL)
@@ -169,7 +238,7 @@ cmdByMimeType:
 			}
 			req.Header.Set("X-Islandora-Args", destinationServer.URL)
 			// set the mimetype to send to the destination server in the Accept header
-			req.Header.Set("Accept", "application/xml")
+			req.Header.Set("Accept", tt.destinationMimeType)
 			req.Header.Set("Authorization", tt.requestAuth)
 			req.Header.Set("Apix-Ldp-Resource", sourceServer.URL)
 
@@ -181,15 +250,23 @@ cmdByMimeType:
 			defer resp.Body.Close()
 			assert.Equal(t, tt.expectedStatus, resp.StatusCode)
 			if !tt.expectMismatch {
-				assert.Equal(t, os.Getenv("NEEDFUL"), tt.expectedBody)
+				// if we're setting up the destination server as the cURL target
+				// make sure it returned
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					t.Fatalf("Unable to read source uri resp body: %v", err)
+				}
+				assert.Equal(t, tt.expectedBody, string(body))
 			}
 		})
 	}
 }
 
-func createMockDestinationServer(content string) *httptest.Server {
+func createMockDestinationServer(t *testing.T, content string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		os.Setenv("NEEDFUL", content)
+		if _, err := w.Write([]byte(content)); err != nil {
+			t.Fatal("Failed to write response in mock server")
+		}
 	}))
 }
 

--- a/scyllaridae.complex.yml
+++ b/scyllaridae.complex.yml
@@ -7,15 +7,15 @@ cmdByMimeType:
     cmd: convert
     args:
       - "pdf:-[0]"
-      # %s is a special string used by scyllaridae
+      # %args is a special string used by scyllaridae
       # populated by the X-Islandora-Args HTTP header
-      - "%s"
+      - "%args"
       - "pdf:-"
   default:
     cmd: convert
     args:
       - "-"
-      # %s is a special string used by scyllaridae
+      # %args is a special string used by scyllaridae
       # populated by the X-Islandora-Args HTTP header
-      - "%s"
+      - "%args"
       - "image:-"


### PR DESCRIPTION
This lets us simplify the ffmpeg scyllaridae.yml considerably to default to

```
allowedMimeTypes:
  - "audio/*"
  - "video/*"
  - "image/jpeg"
  - "image/png"
cmdByMimeType:
  default:
    cmd: ffmpeg
    args:
      - "-f"
      - "%source-mime-ext"
      - "-i"
      - "-"
      - "%args"
      - "-f"
      - "%destination-mime-ext"
      - "-"
```

Where we're using the new `%source-mime-ext` and `%destination-mime-ext` replacement args to get the source/destination file extensions from the mimetype set on the SourceURI and DestinationURI