### PR TITLE
[major] Make a single queue subscriber middleware for other microservices

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+export DOCKER_DEFAULT_PLATFORM=linux/amd64
+
+docker build --build-arg=TAG=main --build-arg=DOCKER_REPOSITORY=$DOCKER_REPOSITORY -t $DOCKER_REPOSITORY/scyllaridae:main .
+
+for EXAMPLE in "$@"; do
+  docker build --build-arg=TAG=main --build-arg=DOCKER_REPOSITORY=$DOCKER_REPOSITORY -t $DOCKER_REPOSITORY/scyllaridae-$EXAMPLE:main examples/$EXAMPLE
+done

--- a/examples/cache-warmer/scyllaridae.yml
+++ b/examples/cache-warmer/scyllaridae.yml
@@ -1,4 +1,3 @@
-queueName: islandora-cache-warmer
 allowedMimeTypes:
   - "*"
 cmdByMimeType:

--- a/examples/coverpage/scyllaridae.yml
+++ b/examples/coverpage/scyllaridae.yml
@@ -1,5 +1,3 @@
-queueName: islandora-pdf-coverpage
-forwardAuth: true
 allowedMimeTypes:
   - "application/pdf"
 cmdByMimeType:
@@ -7,6 +5,3 @@ cmdByMimeType:
     cmd: "/app/cmd.sh"
     args:
       - "%canonical"
-      - "%source-uri"
-      - "%file-upload-uri"
-      - "%destination-uri"

--- a/examples/coverpage/urldecode.lua
+++ b/examples/coverpage/urldecode.lua
@@ -1,0 +1,15 @@
+function decode_percent(s)
+  return s:gsub('%%([0-9A-Fa-f][0-9A-Fa-f])', function(hex)
+    return string.char(tonumber(hex, 16))
+  end)
+end
+
+function Str(el)
+  el.text = decode_percent(el.text)
+  return el
+end
+
+function Code(el)
+  el.text = decode_percent(el.text)
+  return el
+end

--- a/examples/parry/Dockerfile
+++ b/examples/parry/Dockerfile
@@ -1,0 +1,5 @@
+ARG TAG=main
+ARG DOCKER_REPOSITORY=local
+FROM ${DOCKER_REPOSITORY}/scyllaridae:${TAG}
+
+COPY scyllaridae.yml /app/scyllaridae.yml

--- a/examples/parry/scyllaridae.yml
+++ b/examples/parry/scyllaridae.yml
@@ -4,3 +4,5 @@ queueMiddlewares:
     consumers: 3
   - queueName: islandora-cache-warmer
     url: http://cache-warmer:8080
+    consumers: 3
+    noPut: true

--- a/examples/parry/scyllaridae.yml
+++ b/examples/parry/scyllaridae.yml
@@ -1,0 +1,4 @@
+queueMiddlewares:
+  - queueName: islandora-pdf-coverpage
+    url: http://coverpage:8080
+    consumers: 3

--- a/examples/parry/scyllaridae.yml
+++ b/examples/parry/scyllaridae.yml
@@ -2,3 +2,5 @@ queueMiddlewares:
   - queueName: islandora-pdf-coverpage
     url: http://coverpage:8080
     consumers: 3
+  - queueName: islandora-cache-warmer
+    url: http://cache-warmer:8080

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -68,6 +68,7 @@ type QueueMiddleware struct {
 	Url         string `yaml:"url"`
 	Consumers   int    `yaml:"consumers"`
 	ForwardAuth bool   `yaml:"forwardAuth,omitempty"`
+	NoPut       bool   `yaml:"noPut"`
 }
 
 // Command describes the command and arguments to execute for a specific MIME type.

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -25,7 +25,7 @@ type ServerConfig struct {
 	// Label of the server configuration used for identification.
 	//
 	// required: false
-	QueueName string `yaml:"queueName"`
+	QueueMiddlewares []QueueMiddleware `yaml:"queueMiddleware,omitempty"`
 
 	// HTTP method used for sending data to the destination server.
 	//
@@ -61,6 +61,13 @@ type ServerConfig struct {
 	//
 	// required: false
 	MimeTypeFromDestination bool `yaml:"mimeTypeFromDestination,omitempty"`
+}
+
+type QueueMiddleware struct {
+	QueueName   string `yaml:"queueName"`
+	Url         string `yaml:"url"`
+	Consumers   int    `yaml:"Consumers"`
+	ForwardAuth bool   `yaml:"forwardAuth,omitempty"`
 }
 
 // Command describes the command and arguments to execute for a specific MIME type.

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -25,7 +25,7 @@ type ServerConfig struct {
 	// Label of the server configuration used for identification.
 	//
 	// required: false
-	QueueMiddlewares []QueueMiddleware `yaml:"queueMiddleware,omitempty"`
+	QueueMiddlewares []QueueMiddleware `yaml:"queueMiddlewares,omitempty"`
 
 	// HTTP method used for sending data to the destination server.
 	//
@@ -66,7 +66,7 @@ type ServerConfig struct {
 type QueueMiddleware struct {
 	QueueName   string `yaml:"queueName"`
 	Url         string `yaml:"url"`
-	Consumers   int    `yaml:"Consumers"`
+	Consumers   int    `yaml:"consumers"`
 	ForwardAuth bool   `yaml:"forwardAuth,omitempty"`
 }
 

--- a/main.go
+++ b/main.go
@@ -273,6 +273,10 @@ func handleMessage(msg *stomp.Message, middleware scyllaridae.QueueMiddleware) {
 		return
 	}
 
+	if middleware.NoPut {
+		return
+	}
+
 	// Create a pipe to stream the data from resp.Body to the PUT request body
 	pr, pw := io.Pipe()
 	defer pr.Close()

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func main() {
 func MessageHandler(w http.ResponseWriter, r *http.Request) {
 	slog.Info(r.RequestURI, "method", r.Method, "ip", r.RemoteAddr, "proto", r.Proto)
 
-	if r.Method != http.MethodGet && r.Method != http.MethodPost {
+	if r.Method != http.MethodGet {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
 	"log/slog"
@@ -9,8 +8,8 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"os/exec"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
@@ -34,20 +33,25 @@ func init() {
 }
 
 func main() {
-	// either subscribe to activemq directly
-	if config.QueueName != "" {
-		subscribed := make(chan bool)
+	if len(config.QueueMiddlewares) > 0 {
 		stopChan := make(chan os.Signal, 1)
 		signal.Notify(stopChan, os.Interrupt, syscall.SIGTERM)
 
-		go RecvStompMessages(config.QueueName, subscribed)
+		var wg sync.WaitGroup
 
-		select {
-		case <-subscribed:
-			slog.Info("Subscription to queue successful")
-		case <-stopChan:
-			slog.Info("Received stop signal, exiting")
-			return
+		for _, middleware := range config.QueueMiddlewares {
+			wg.Add(1)
+			go func(middleware scyllaridae.QueueMiddleware) {
+				defer wg.Done()
+				messageChan := make(chan *stomp.Message, middleware.Consumers)
+
+				// Start the specified number of worker goroutines
+				for i := 0; i < middleware.Consumers; i++ {
+					go worker(messageChan, middleware)
+				}
+
+				RecvStompMessages(middleware.QueueName, messageChan)
+			}(middleware)
 		}
 
 		<-stopChan
@@ -140,22 +144,30 @@ func MessageHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func RecvStompMessages(queueName string, subscribed chan bool) {
-	defer close(subscribed)
+func worker(messageChan <-chan *stomp.Message, middleware scyllaridae.QueueMiddleware) {
+	for msg := range messageChan {
+		handleMessage(msg, middleware)
+	}
+}
+
+func RecvStompMessages(queueName string, messageChan chan<- *stomp.Message) {
 	attempt := 0
 	maxAttempts := 30
 	for attempt = 0; attempt < maxAttempts; attempt += 1 {
-		if err := connectAndSubscribe(queueName, subscribed); err != nil {
-			slog.Error("resubscribing", "error", err)
+		if err := connectAndSubscribe(queueName, messageChan); err != nil {
+			slog.Error("resubscribing", "queue", queueName, "error", err)
 			if err := retryWithExponentialBackoff(attempt, maxAttempts); err != nil {
-				slog.Error("Failed subscribing after too many failed attempts", "attempts", attempt)
+				slog.Error("Failed subscribing after too many failed attempts", "queue", queueName, "attempts", attempt)
 				return
 			}
+		} else {
+			// Subscription was successful
+			break
 		}
 	}
 }
 
-func connectAndSubscribe(queueName string, subscribed chan bool) error {
+func connectAndSubscribe(queueName string, messageChan chan<- *stomp.Message) error {
 	addr := os.Getenv("STOMP_SERVER_ADDR")
 	if addr == "" {
 		addr = "activemq:61613"
@@ -207,61 +219,46 @@ func connectAndSubscribe(queueName string, subscribed chan bool) error {
 		}
 	}()
 	slog.Info("Server subscribed to", "queue", queueName)
-	subscribed <- true
 
 	for msg := range sub.C {
 		if msg == nil || len(msg.Body) == 0 {
-			// if the subscription isn't active return so we can try reconnecting
 			if !sub.Active() {
 				return fmt.Errorf("no longer subscribed to %s", queueName)
 			}
-			// else just try reading again. There's probably just no messages in the queue
 			continue
 		}
-		handleStompMessage(msg)
+		messageChan <- msg // Send the message to the channel
 	}
 
 	return nil
 }
 
-func handleStompMessage(msg *stomp.Message) {
-	message, err := api.DecodeEventMessage(msg.Body)
+func handleMessage(msg *stomp.Message, middleware scyllaridae.QueueMiddleware) {
+	req, err := http.NewRequest("POST", middleware.Url, bytes.NewReader(msg.Body))
 	if err != nil {
-		slog.Error("could not read the event message", "err", err, "msg", string(msg.Body))
+		slog.Error("Error creating HTTP request", "url", middleware.Url, "err", err)
 		return
 	}
 
-	message.Authorization = msg.Header.Get("Authorization")
-	cmd, err := scyllaridae.BuildExecCommand(message, config)
-	if err != nil {
-		slog.Error("Error building command", "err", err)
-		return
-	}
-
-	runCommand(cmd)
-}
-
-func runCommand(cmd *exec.Cmd) {
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		slog.Error("error creating stdout pipe", "err", err)
-		return
-	}
-	scanner := bufio.NewScanner(stdout)
-	go func() {
-		for scanner.Scan() {
-			slog.Info("cmd output", "stdout", scanner.Text())
+	if middleware.ForwardAuth {
+		auth := msg.Header.Get("Authorization")
+		if auth != "" {
+			req.Header.Set("Authorization", auth)
 		}
-	}()
+	}
 
-	var stdErr bytes.Buffer
-	cmd.Stderr = &stdErr
-	if err := cmd.Start(); err != nil {
-		slog.Error("Error starting command", "cmd", cmd.String(), "err", stdErr.String())
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		slog.Error("Error sending HTTP POST request", "url", middleware.Url, "err", err)
 		return
 	}
-	if err := cmd.Wait(); err != nil {
-		slog.Error("command finished with error", "err", stdErr.String())
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		slog.Info("Successfully delivered message to", "url", middleware.Url, "status", resp.StatusCode)
+	} else {
+		slog.Error("Failed to deliver message", "url", middleware.Url, "status", resp.StatusCode)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -2,127 +2,14 @@ package main
 
 import (
 	"io"
-	"log/slog"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
-	"time"
 
-	stomp "github.com/go-stomp/stomp/v3"
-	ss "github.com/go-stomp/stomp/v3/server"
 	scyllaridae "github.com/lehigh-university-libraries/scyllaridae/internal/config"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestRecvStompMessages(t *testing.T) {
-	addr := "127.0.0.1:61613"
-	os.Setenv("STOMP_SERVER_ADDR", addr)
-
-	l, err := net.Listen("tcp", addr)
-	if err != nil {
-		t.Fatalf("Could not start stomp mock server: %v", err)
-	}
-	defer func() { l.Close() }()
-	go func() {
-		err := ss.Serve(l)
-		if err != nil {
-			slog.Error("Error starting mock stomp server", "err", err)
-			os.Exit(1)
-		}
-	}()
-
-	os.Setenv("SCYLLARIDAE_YML", `
-queueName: "test-queue"
-allowedMimeTypes:
-  - "*"
-cmdByMimeType:
-  default:
-    cmd: touch
-    args:
-      - "%target"
-`)
-	config, err = scyllaridae.ReadConfig("")
-	if err != nil {
-		t.Fatalf("Could not read YML: %v", err)
-		os.Exit(1)
-	}
-
-	subscribed := make(chan bool, 1)
-	go RecvStompMessages("test-queue", subscribed)
-	<-subscribed
-
-	conn, err := stomp.Dial("tcp", addr,
-		stomp.ConnOpt.AcceptVersion(stomp.V11),
-		stomp.ConnOpt.AcceptVersion(stomp.V12),
-		stomp.ConnOpt.Host("dragon"),
-		stomp.ConnOpt.Header("nonce", "B256B26D320A"))
-
-	if err != nil {
-		t.Fatalf("Could not connection to stomp mock server: %v", err)
-	}
-
-	err = conn.Send(
-		"test-queue",
-		"text/plain",
-		[]byte(`{
-	"@context": "https://www.w3.org/ns/activitystreams",
-	"actor": {
-		"type": "Person",
-		"id": "urn:uuid:b3f0a1ba-fd0c-4977-a123-3faf470374f2",
-		"url": [
-			{
-				"name": "Canonical",
-				"type": "Link",
-				"href": "https://islandora.dev/user/1",
-				"mediaType": "text/html",
-				"rel": "canonical"
-			}
-		]
-	},
-	"object": {
-		"id": "urn:uuid:abcdef01-2345-6789-abcd-ef0123456789",
-		"url": [
-			{
-				"name": "Canonical",
-				"type": "Link",
-				"href": "https://islandora.dev/node/1",
-				"mediaType": "text/html",
-				"rel": "canonical"
-			},
-			{
-				"name": "JSON",
-				"type": "Link",
-				"href": "https://islandora.dev/node/1?_format=json",
-				"mediaType": "application/json",
-				"rel": "alternate"
-			},
-			{
-				"name": "JSONLD",
-				"type": "Link",
-				"href": "https://islandora.dev/node/1?_format=jsonld",
-				"mediaType": "application/ld+json",
-				"rel": "alternate"
-			}
-		],
-		"isNewVersion": true
-	},
-	"target": "/tmp/stomp.success",
-	"type": "Update",
-	"summary": "Update a Node"
-}`))
-	if err != nil {
-		t.Fatalf("Could not send test stomp message: %v", err)
-	}
-
-	// give the command some time to finish
-	time.Sleep(time.Second * 5)
-
-	// make sure the command ran
-	f := "/tmp/stomp.success"
-	assert.FileExists(t, f)
-}
 
 type Test struct {
 	name                string


### PR DESCRIPTION
Closes #14 

Some microservices need more information than just the source media file and the REST endpoint to place the derivative (i.e. the default context sent by Islandora's alpaca derivative middleware). Sometimes you need additional metadata around a media and/or its parent node to make the derivative. For such cases, alpaca's middleware model is not sufficient.

So we're creating a new middleware model that can read the message sent to activemq (which contains the necessary information) and send the entire event to a microservice. This new middleware has its own scyllaridae spec to define what queue to read from, and a URL to forward the entire Islandora event to. This new middleware is meant to be deployed alongside the ISLE stack so it can read from activemq without opening ports outside the localhost/docker network/firewall. This approach is implemented in opposition of alpaca's approach of parsing the Islandora event and sending its disparate components to an endpoint via HTTP headers. Instead, this middleware will send the entire event so those microservices that need additional context can access that information without having to subscribe directly to the activmq queue to read it. This unlocks having microservices that need this additional context from running on the same hardware as the ISLE stack; instead, these types of microservices can be distributed to other compute locations similar to other microservices with less context/metadata requirements.

This PR also adds concurrency to allow for multi-threaded execution to the respective microservices the middleware acts on behalf of.